### PR TITLE
🚀 add alpha version

### DIFF
--- a/hatch_build.py
+++ b/hatch_build.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import platform
+import re
 import shutil
 import sys
 import tarfile
@@ -83,7 +84,7 @@ class SpecialBuildHook(BuildHookInterface):
         file_path = self.temp_dir / f"{self.BIN_NAME}_{target_os_info}_{target_arch}.tar.gz"
         request.urlretrieve(
             self.YAMLFMT_REPO.format(
-                version=self.metadata.version,
+                version=re.sub(r"[ab]\d+$", "", self.metadata.version),  # 去掉版本号中的后缀, alpha/beta
                 target_os_info=target_os_info_to_go_os.get(target_os_info, target_os_info),
                 target_arch=target_arch_to_go_arch.get(target_arch, target_arch),
             ),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "google-yamlfmt"
-version = "0.16.0"
+version = "0.16.0-alpha.0"
 description = "A tool for formatting YAML files, yamlfmt from Google: https://github.com/google/yamlfmt"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
版本没法保持一致了，策略大概是这样
* 如果 google 那边发 alpha, 我们这不同步
* 我们这加 alpha 主要是一些发版错误加的版本号