### PR TITLE
:recycle: refactor: adopt PEP 639 license metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,8 @@ name = "google-yamlfmt"
 version = "0.21.0"
 description = "A tool for formatting YAML files, yamlfmt from Google: https://github.com/google/yamlfmt"
 readme = "README.md"
-license = { text = "MIT" }
+license = "MIT"
+license-files = ["LICENSE"]
 requires-python = ">=3.9"
 dependencies = []
 


### PR DESCRIPTION
## 改动动机

当前项目的许可证声明仍使用旧式元数据写法，尚未完整采用 PEP 639 推荐的 SPDX 许可证表达式。为减少旧 license metadata 的兼容性负担，并让构建产物直接产出标准的 `License-Expression` 元数据，这个 PR 将许可证配置迁移到 PEP 639 写法。

## 改动说明

- 将 `project.license` 从旧式表结构改为 SPDX 字符串
- 补充 `project.license-files`
- 移除旧的 license classifier（如仓库中存在）
- 不涉及 license metadata 之外的改动

## 仓库情况

该仓库虽未声明 license classifier，但仍使用旧式 `license = { text = "MIT" }`，本次一并迁移到 PEP 639 SPDX 写法。

## PEP 639 说明

PEP 639 引入了基于 SPDX 的许可证表达方式，推荐在打包元数据中使用标准化的 `License-Expression` 与 `License-File`，以替代旧的 license classifier / 非标准文本写法。

PEP 639 链接：https://peps.python.org/pep-0639/

## 验证结果

已在本地执行构建验证：

```bash
uv build
```

验证结果：

- 构建成功生成 sdist 与 wheel
- wheel 元数据包含正确的 `License-Expression`
- wheel 元数据包含 `License-File: LICENSE`
- 不再包含旧的 license classifier
